### PR TITLE
Add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+yarn-error.log
+
 node_modules/
 
 *.tsbuildinfo


### PR DESCRIPTION
This PR adds the `yarn-error.log` file to the `.gitignore` list.